### PR TITLE
Copy and Open in Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,20 @@
 # Mosbot::Cli
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/mosbot/cli`. To experiment with that code, run `bin/console` for an interactive prompt.
+`mosbot` will generate a My Oracle Support URL based on a document ID, bug number, patch number or community idea. To use mosbot, enter the URL type and the number.
 
-TODO: Delete this and the text above, and describe your gem
+    $ mosbot doc 123456.1
+    $ https://support.oracle.com/epmos/faces/DocumentDisplay?id=123456.1
+
+    $ mosbot bug 1222341
+    $ https://support.oracle.com/epmos/faces/BugMatrix?id=1222341
+
+`mosbot` will default to documents. If you specify only a number `mosbot` will return a document URL.
+
+You can also configure `mosbot` to copy the output URL or open a browser window with the URL. The environment variables `MOS_COPY_URL=true` and `MOS_OPEN_URL=true` control how `mosbot` handles the output.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
-```ruby
-gem 'mosbot-cli'
-```
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install mosbot-cli
-
-## Usage
-
-TODO: Write usage instructions here
-
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+    $ gem install mosbot
 
 ## Contributing
 

--- a/bin/mosbot
+++ b/bin/mosbot
@@ -22,6 +22,7 @@ end
 # constants
 OS_CONST            = os
 MOS_COPY_URL        = ENV['MOS_COPY_URL'] || "false"
+MOS_OPEN_URL        = ENV['MOS_OPEN_URL'] || "false"
 
 case type
 when "doc"

--- a/bin/mosbot
+++ b/bin/mosbot
@@ -4,6 +4,44 @@
 type  = ARGV.shift || "help"
 id    = ARGV.shift
 
+# setup environment
+MOS_BOT_CONF = ENV['MOS_BOT_CONF'] || "#{ENV['HOME']}/.mosbot.conf"
+if File.exists?(MOS_BOT_CONF) then
+    File.readlines(MOS_BOT_CONF).each do |line|
+        if line.start_with? "#" then
+            next 
+        else
+            key, value = line.split "="
+            ENV[key] = value.strip
+        end
+    end
+end
+
+def os
+  @os ||= (
+      host_os = RbConfig::CONFIG['host_os']
+          case host_os
+          when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+              :windows
+          when /darwin|mac os/
+              :macosx
+          when /linux/
+              :linux
+          when /solaris|bsd/
+              :unix
+          else
+              raise Error::WebDriverError, "unknown os: #{host_os.inspect}"
+          end
+   )
+end
+
+def handle_output
+
+end
+
+
+
+
 case type
 when "doc"
   mosurl = "https://support.oracle.com/epmos/faces/DocumentDisplay?id=" + id
@@ -18,5 +56,6 @@ when "help"
 else
   mosurl = "https://support.oracle.com/epmos/faces/DocumentDisplay?id=" + type
 end
+
 
 puts mosurl

--- a/bin/mosbot
+++ b/bin/mosbot
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require_relative '../lib/mosbot'
+
 #options
 type  = ARGV.shift || "help"
 id    = ARGV.shift
@@ -17,30 +19,9 @@ if File.exists?(MOS_BOT_CONF) then
     end
 end
 
-def os
-  @os ||= (
-      host_os = RbConfig::CONFIG['host_os']
-          case host_os
-          when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
-              :windows
-          when /darwin|mac os/
-              :macosx
-          when /linux/
-              :linux
-          when /solaris|bsd/
-              :unix
-          else
-              raise Error::WebDriverError, "unknown os: #{host_os.inspect}"
-          end
-   )
-end
-
-def handle_output
-
-end
-
-
-
+# constants
+OS_CONST            = os
+MOS_COPY_URL        = ENV['MOS_COPY_URL'] || "false"
 
 case type
 when "doc"
@@ -57,5 +38,4 @@ else
   mosurl = "https://support.oracle.com/epmos/faces/DocumentDisplay?id=" + type
 end
 
-
-puts mosurl
+handle_output(mosurl)

--- a/lib/mosbot.rb
+++ b/lib/mosbot.rb
@@ -30,4 +30,12 @@ def handle_output(url)
       out = `echo "#{url}" | clip`
     end
   end
+  if "#{MOS_OPEN_URL}" == "true"
+    case "#{OS_CONST}"
+    when "macosx"
+      out = `open #{url}`
+    when "windows"
+      out = `start #{url}`
+    end
+  end
 end

--- a/lib/mosbot.rb
+++ b/lib/mosbot.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+require 'rbconfig'
+
+def os
+  @os ||= (
+      host_os = RbConfig::CONFIG['host_os']
+          case host_os
+          when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+              :windows
+          when /darwin|mac os/
+              :macosx
+          when /linux/
+              :linux
+          when /solaris|bsd/
+              :unix
+          else
+              raise Error::WebDriverError, "unknown os: #{host_os.inspect}"
+          end
+   )
+end
+
+def handle_output(url)
+  puts url
+  if "#{MOS_COPY_URL}" == "true" 
+    case "#{OS_CONST}"
+    when "macosx", "linux"
+      out = `echo "#{url}" | pbcopy`
+    when "windows"
+      out = `echo "#{url}" | clip`
+    end
+  end
+end


### PR DESCRIPTION
New features to address #2 and #3 

Set environment variables or use the `MOS_BOT_CONF` environment variable to point to the configuration (defaults to `~/.mosbot.conf`).
`~/.mosbot.conf`
```
MOS_OPEN_URL=true
MOS_COPY_URL=true
```