### PR TITLE
Command line support for Copy/Open

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@
     $ mosbot bug 1222341
     $ https://support.oracle.com/epmos/faces/BugMatrix?id=1222341
 
-`mosbot` will default to documents. If you specify only a number `mosbot` will return a document URL.
+`mosbot` will default to documents. If you specify only a number `mosbot` will return a document URL. Supported types are:
+
+* `doc`
+* `bug`
+* `patch`
+* `idea`
 
 You can also configure `mosbot` to copy the output URL or open a browser window with the URL. The environment variables `MOS_COPY_URL=true` and `MOS_OPEN_URL=true` control how `mosbot` handles the output.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Mosbot::Cli
 
-`mosbot` will generate a My Oracle Support URL based on a document ID, bug number, patch number or community idea. To use mosbot, enter the URL type and the number.
+`mosbot` will generate a My Oracle Support URL based on a document ID, bug number, patch number or community idea.
+
+## Installation
+
+    $ gem install mosbot
+
+## Usage
+
+To use `mosbot`, enter the URL type and the number.
 
     $ mosbot doc 123456.1
     $ https://support.oracle.com/epmos/faces/DocumentDisplay?id=123456.1
@@ -15,11 +23,27 @@
 * `patch`
 * `idea`
 
+There are two parameters for `mosbot`
+
+* `-c`: Copy the URL to your clipboard
+* `-o`: Open the URL in your browser
+
 You can also configure `mosbot` to copy the output URL or open a browser window with the URL. The environment variables `MOS_COPY_URL=true` and `MOS_OPEN_URL=true` control how `mosbot` handles the output.
 
-## Installation
+`MOS_COPY_URL` and `MOS_OPEN_URL` options default to `false`.
 
-    $ gem install mosbot
+## Config File
+
+`mosbot` will also ready from a configuration file. The default config file is `~/.mosbot.conf`. You can override that file by using the `MOS_BOT_CONF` environment variable.
+
+The `.mosbot.conf` file stores key=value pairs:
+
+    ```ini
+    MOS_COPY_URL=true
+    MOS_OPEN_URL=true
+    ```
+
+The configuration file takes precedence over environment variables.
 
 ## Contributing
 

--- a/bin/mosbot
+++ b/bin/mosbot
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
-require_relative '../lib/mosbot'
+require 'mosbot'
+# require_relative '../lib/mosbot'
 
 #options
 type  = ARGV.shift || "help"

--- a/bin/mosbot
+++ b/bin/mosbot
@@ -20,6 +20,16 @@ if File.exists?(MOS_BOT_CONF) then
     end
 end
 
+# grab command line options
+ARGV.each do |arg|
+  case arg
+  when "-o"
+    ENV['MOS_OPEN_URL']="true"
+  when "-c"
+    ENV['MOS_COPY_URL']="true"
+  end
+end
+
 # constants
 OS_CONST            = os
 MOS_COPY_URL        = ENV['MOS_COPY_URL'] || "false"

--- a/mosbot.gemspec
+++ b/mosbot.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "mosbot"
-  spec.version       = "0.2.2"
+  spec.version       = "0.2.3"
   spec.authors       = ["Dan Iverson", "Kyle Benson"]
   spec.email         = ["dan@psadmin.io"]
   spec.files         = ["lib/mosbot.rb"]

--- a/mosbot.gemspec
+++ b/mosbot.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "mosbot"
-  spec.version       = "0.1.0"
+  spec.version       = "0.2.0"
   spec.authors       = ["Dan Iverson", "Kyle Benson"]
   spec.email         = ["dan@psadmin.io"]
 

--- a/mosbot.gemspec
+++ b/mosbot.gemspec
@@ -4,10 +4,10 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "mosbot"
-  spec.version       = "0.2.1"
+  spec.version       = "0.2.2"
   spec.authors       = ["Dan Iverson", "Kyle Benson"]
   spec.email         = ["dan@psadmin.io"]
-
+  spec.files         = ["lib/mosbot.rb"]
   spec.summary       = %q{Generates MOS URLs based on a type and number}
   spec.description   = %q{Use mosbot to generate URLs for MOS Docs, Bugs, Ideas and Patches.}
   spec.homepage      = "https://github.com/psadmin-io/mosbot-cli"

--- a/mosbot.gemspec
+++ b/mosbot.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "mosbot"
-  spec.version       = "0.2.0"
+  spec.version       = "0.2.1"
   spec.authors       = ["Dan Iverson", "Kyle Benson"]
   spec.email         = ["dan@psadmin.io"]
 


### PR DESCRIPTION
New command line options `-c` and `-o` to copy and open the URLs.

Better support for #2, #3 and #4.