### PR TITLE
Check how many args are being passed

### DIFF
--- a/bin/mosbot
+++ b/bin/mosbot
@@ -55,7 +55,7 @@ OS_CONST        = os
 MOS_COPY_URL    = ENV['MOS_COPY_URL'] || "false"
 MOS_OPEN_URL    = ENV['MOS_OPEN_URL'] || "false"
 
-if type == "help" 
+if type == "help" || id == "0"
   display_help()
 else
   mosurl = generate_url(type, id)

--- a/bin/mosbot
+++ b/bin/mosbot
@@ -20,7 +20,7 @@ type            = 'doc'
 id              = '0'
 
 # grab command line options
-if ARGV.empty?
+if ARGV.empty? || ARGV.length < 2
   type='help'
 else
   ARGV.each do |arg|


### PR DESCRIPTION
Check to make sure that at least 2 args are being passed to mosbot, if less than 2 show the help output. This will avoid pulling bugs/docs with the id set to 0.