### PR TITLE
URI.Open Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The configuration file takes precedence over environment variables.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/mosbot-cli. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/psadmin-io/mosbot-cli. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
@@ -55,4 +55,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Mosbot::Cli project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/mosbot-cli/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Mosbot::Cli project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/psadmin-io/mosbot-cli/blob/master/CODE_OF_CONDUCT.md).

--- a/lib/mosbot.rb
+++ b/lib/mosbot.rb
@@ -2,6 +2,7 @@
 
 require 'rbconfig'
 require 'open-uri'
+require 'uri'
 require 'cgi'
 
 def os
@@ -46,7 +47,7 @@ end
 
 def get_title(mospuburl)
   begin
-    open(mospuburl) do |f|
+    URI.open(mospuburl) do |f|
       str = f.read
       page_title = CGI.unescapeHTML(str.scan(/<title>(.*?)<\/title>/)[0][0])
     end

--- a/mosbot.gemspec
+++ b/mosbot.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "mosbot"
-  spec.version       = "2.0.1"
+  spec.version       = "2.0.2"
   spec.authors       = ["Dan Iverson", "Kyle Benson"]
   spec.email         = ["dan@psadmin.io"]
   spec.files         = ["lib/mosbot.rb"]


### PR DESCRIPTION
Use `URI.Open` to silence warnings.

Fixes #18 